### PR TITLE
Changed string method to text method

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ def accounts(regno, fyend):
             abort(404, description="No accounts available for this charity")
         for tr in browser.get_current_page().find_all('tr', class_='govuk-table__row'):
             cells = list(tr.find_all("td"))
-            if cells and (cells[0].string.strip().lower() == 'accounts and tar') and (cells[1].string.strip() == fyend.strftime("%d %B %Y")):
+            if cells and (cells[0].string.strip().lower() == 'accounts and tar') and (cells[1].text[:30].strip() == fyend.strftime("%d %B %Y")):
                 return redirect(tr.find("a").attrs["href"], code=303)
         abort(404, description="This account could be found for this charity")
     abort(404, description="Cannot access accounts for this charity")


### PR DESCRIPTION
The string method in cells[1] (line 44) brings back None type when the Charity Commission write something where the date is normally kept.  The text method allows us to get the date from the tr tags in cases where p tags inside them occur.  Using string instead of text in cells[1] was preventing retrieval of URL for accounts where a note was left in the fyend table column.  Example: https://register-of-charities.charitycommission.gov.uk/charity-search/-/charity-details/287785/accounts-and-annual-returns.